### PR TITLE
update: prevent erc721 token factory update its parameters

### DIFF
--- a/contracts/upgradeable_contracts/omnibridge_nft/components/factory/ERC721TokenFactory.sol
+++ b/contracts/upgradeable_contracts/omnibridge_nft/components/factory/ERC721TokenFactory.sol
@@ -6,8 +6,9 @@ import "../bridged/ERC721TokenProxy.sol";
 import "../../../../tokens/ERC721BridgeToken.sol";
 import "../../../Initializable.sol";
 import "../../../Upgradeable.sol";
+import "../../../Ownable.sol";
 
-contract ERC721TokenFactory is Initializable, Upgradeable {
+contract ERC721TokenFactory is Initializable, Upgradeable, Ownable {
   event ERC721NativeContractCreated(address indexed _collection);
   event ERC721BridgeContractCreated(address indexed _collection);
 

--- a/contracts/upgradeable_contracts/omnibridge_nft/components/factory/ERC721TokenFactory.sol
+++ b/contracts/upgradeable_contracts/omnibridge_nft/components/factory/ERC721TokenFactory.sol
@@ -6,9 +6,8 @@ import "../bridged/ERC721TokenProxy.sol";
 import "../../../../tokens/ERC721BridgeToken.sol";
 import "../../../Initializable.sol";
 import "../../../Upgradeable.sol";
-import "../../../Ownable.sol";
 
-contract ERC721TokenFactory is Initializable, Upgradeable, Ownable {
+contract ERC721TokenFactory is Initializable, Upgradeable {
   event ERC721NativeContractCreated(address indexed _collection);
   event ERC721BridgeContractCreated(address indexed _collection);
 
@@ -53,32 +52,16 @@ contract ERC721TokenFactory is Initializable, Upgradeable, Ownable {
     return addressStorage[ERC721_TOKEN_BRIDGE_IMAGE_CONTRACT];
   }
 
-  function setERC721BridgeImage(address erc721BridgeImage_) public onlyOwner {
-    _setERC721BridgeImage(erc721BridgeImage_);
-  }
-
   function erc721NativeImage() public view returns (address) {
     return addressStorage[ERC721_TOKEN_NATIVE_IMAGE_CONTRACT];
-  }
-
-  function setERC721NativeImage(address erc721NativeImage_) public onlyOwner {
-    _setERC721NativeImage(erc721NativeImage_);
   }
 
   function bridge() public view returns (address) {
     return addressStorage[BRIDGE_CONTRACT];
   }
 
-  function setBridge(address bridge_) public onlyOwner {
-    _setBridge(bridge_);
-  }
-
   function oppositeBridge() public view returns (address) {
     return addressStorage[OPPOSITE_BRIDGE_CONTRACT];
-  }
-
-  function setOppositeBridge(address oppositeBridge_) public onlyOwner {
-    _setOppositeBridge(oppositeBridge_);
   }
 
   function nativeTokenOf(uint256 id_) public view returns (address) {

--- a/test/omnibridge_nft/common.test.js
+++ b/test/omnibridge_nft/common.test.js
@@ -1225,8 +1225,6 @@ function runTests(accounts, isHome) {
             // )
             // expect(oppositeBridge.address).to.eql('0x32cF26d114e5cCEc96B0666185d72a2F32D6A685')
             // await tokenFactoryERC721.transferOwnership(owner, { from: user3 })
-            // await tokenFactoryERC721.setBridge(bridge)
-            // await tokenFactoryERC721.setOppositeBridge(oppositeBridge.address)
             // await tokenFactoryERC721.deployERC721NativeContract('TEST', 'TST')
             // const event = await getEvents(tokenFactoryERC721, { event: 'ERC721NativeContractCreated' })
             // expect(event.length).to.be.equal(1)
@@ -1255,8 +1253,7 @@ function runTests(accounts, isHome) {
             )
             expect(bridge.address).to.eql('0x32cF26d114e5cCEc96B0666185d72a2F32D6A685')
             await tokenFactoryERC721.transferOwnership(owner, { from: user3 })
-            await tokenFactoryERC721.setBridge(bridge.address)
-            await tokenFactoryERC721.setOppositeBridge(oppositeBridge)
+
             if (isHome) {
               await bridge.initialize(
                 ambBridgeContract.address,

--- a/test/omnibridge_nft/erc721_token_factory.test.js
+++ b/test/omnibridge_nft/erc721_token_factory.test.js
@@ -89,61 +89,6 @@ contract('ERC721TokenFactory', (accounts) => {
     beforeEach(async () => {
       await initialize().should.be.fulfilled
     })
-
-    describe('setERC721BridgeImage', () => {
-      it('should allow owner to change erc271 bridge image', async () => {
-        const newTokenBridgeImageERC721 = await ERC721BridgeToken.new('TEST', 'TST', owner)
-        await tokenFactoryERC721.setERC721BridgeImage(newTokenBridgeImageERC721.address).should.be.fulfilled
-        expect(await tokenFactoryERC721.erc721BridgeImage()).to.be.equal(newTokenBridgeImageERC721.address)
-      })
-
-      it('should not allow not owner to change erc271 bridge image', async () => {
-        const newTokenBridgeImageERC721 = await ERC721BridgeToken.new('TEST', 'TST', owner)
-        await tokenFactoryERC721.setERC721BridgeImage(newTokenBridgeImageERC721.address, { from: other }).should.be
-          .rejected
-      })
-    })
-
-    describe('setERC721NativeImage', () => {
-      it('should allow owner to change erc271 native image', async () => {
-        const newTokenNativeImageERC721 = await ERC721NativeToken.new('TEST', 'TST')
-        await tokenFactoryERC721.setERC721NativeImage(newTokenNativeImageERC721.address).should.be.fulfilled
-        expect(await tokenFactoryERC721.erc721NativeImage()).to.be.equal(newTokenNativeImageERC721.address)
-      })
-
-      it('should not allow not owner to change erc271 native image', async () => {
-        const newTokenNativeImageERC721 = await ERC721NativeToken.new('TEST', 'TST')
-        await tokenFactoryERC721.setERC721NativeImage(newTokenNativeImageERC721.address, { from: other }).should.be
-          .rejected
-      })
-    })
-
-    describe('setBridge', () => {
-      it('should allow owner to change bridge contract', async () => {
-        const newBridge = await OmnibridgeMock.new('SUFFIX')
-        await tokenFactoryERC721.setBridge(newBridge.address).should.be.fulfilled
-        expect(await tokenFactoryERC721.bridge()).to.be.equal(newBridge.address)
-      })
-
-      it('should not allow not owner to change bridge contract', async () => {
-        const newBridge = await OmnibridgeMock.new('SUFFIX')
-        await tokenFactoryERC721.setBridge(newBridge.address, { from: other }).should.be.rejected
-      })
-    })
-
-    describe('setOppositeBridge', () => {
-      it('should allow owner to change opposite bridge contract', async () => {
-        const newOppositeBridge = '0xAfb77d544aFc1e2aD3dEEAa20F3c80859E7Fc3C9'
-        await tokenFactoryERC721.setOppositeBridge(newOppositeBridge).should.be.fulfilled
-        expect(await tokenFactoryERC721.oppositeBridge()).to.be.equal(newOppositeBridge)
-      })
-
-      it('should not allow not owner to change bridge contract', async () => {
-        const newOppositeBridge = '0xAfb77d544aFc1e2aD3dEEAa20F3c80859E7Fc3C9'
-        await tokenFactoryERC721.setOppositeBridge(newOppositeBridge, { from: other }).should.be.rejected
-      })
-    })
-
     describe('deployERC721NativeContract', () => {
       it('should allow deploy native contract', async () => {
         expect(await tokenFactoryERC721.nativeTokenOf(0)).to.be.eql(ZERO_ADDRESS)


### PR DESCRIPTION
- To keep both chains deploying the same address, we need to keep those things the same in both chains:
- parameters able to update now: 
   - erc721BridgeImage address
   - erc721NativeImage address
   - bridge address
   - oppositeBridge address

| Home network               | Foreign network            |
|----------------------------|----------------------------|
| ERC721TokenFactory address | ERC721TokenFactory address |
| salt                       | salt                       |
| ERC721TokenProxy bytecode  | ERC721TokenProxy bytecode  |
| erc721BridgeImage address  | erc721NativeImage address  |
| erc721NativeImage address  | erc721BridgeImage address  |
| bridge address             | oppositeBridge address     |
| oppositeBridge address     | bridge address             |
| collectionId               | collectionId               |
| owner address              | owner address              |

the ERC721BridgeToken will not same ERC721NativeToken if:
- user deploys ERC721NativeToken with erc721BridgeImage address
- the owner of the bridge changed the erc721BridgeImage address because need to update the logic of erc721BridgeImage
- user bridging the above token => the bridge deploy ERC721BridgeToken with new erc721BridgeImage address => will be not same address

If not allow changing those params, What happens when we want to change the logic of ERC721BridgeToken?
- ERC721BridgeToken, ERC721NativeToken support upgrable

Current: 
<img width="853" alt="image" src="https://user-images.githubusercontent.com/100658449/218687909-8264134e-36b7-4c2e-b4ad-ee82a07f31a1.png">

After:
<img width="757" alt="image" src="https://user-images.githubusercontent.com/100658449/218688874-e5ee89c6-0854-4261-8c3c-dd59dc0a625f.png">
