### PR TITLE
feat: token factory not depend on token image

### DIFF
--- a/contracts/interfaces/IERC721TokenFactory.sol
+++ b/contracts/interfaces/IERC721TokenFactory.sol
@@ -5,7 +5,8 @@ interface IERC721TokenFactory {
         string memory _name,
         string memory _symbol,
         uint256 _id,
-        address owner_
+        address _owner,
+        address _image
     ) external returns (address);
 
     function nativeTokenOf(uint256 id_) external view returns (address);

--- a/contracts/interfaces/IGUERC721Metadata.sol
+++ b/contracts/interfaces/IGUERC721Metadata.sol
@@ -3,4 +3,5 @@ pragma solidity ^0.7.0;
 interface IGUERC721Metadata {
     function id() external view returns (uint256);
     function owner() external view returns (address);
+    function implementation() external view returns (address);
 }

--- a/contracts/mocks/OmnibridgeMock.sol
+++ b/contracts/mocks/OmnibridgeMock.sol
@@ -8,8 +8,9 @@ contract OmnibridgeMock {
     string memory _name,
     string memory _symbol,
     uint256 _id,
-    address owner_
+    address _owner,
+    address _image
   ) public {
-    IERC721TokenFactory(_factory).deployERC721BridgeContract(_name, _symbol, _id, owner_);
+    IERC721TokenFactory(_factory).deployERC721BridgeContract(_name, _symbol, _id, _owner, _image);
   }
 }

--- a/contracts/upgradeable_contracts/omnibridge_nft/components/native/MetadataReader.sol
+++ b/contracts/upgradeable_contracts/omnibridge_nft/components/native/MetadataReader.sol
@@ -63,6 +63,12 @@ contract MetadataReader is Ownable {
         return status ? abi.decode(data, (address)) : tx.origin;
     }
 
+    function _readImage(address _token) internal view returns (address) {
+        (bool status, bytes memory data) = _token.staticcall(abi.encodeWithSelector(IGUERC721Metadata.implementation.selector));
+
+        return status ? abi.decode(data, (address)) : address(0);
+    }
+
     /**
      * @dev Internal function for reading ERC721 token URI.
      * @param _token address of the ERC721 token contract.

--- a/deploy/deploy.js
+++ b/deploy/deploy.js
@@ -26,8 +26,6 @@ async function deployOmnibridgeNFT() {
   await preDeploy()
   const {
     foreignNativeTokenImageERC721,
-    homeBridgeTokenImageERC721,
-    foreignBridgeTokenImageERC721,
     homeNativeTokenImageERC721,
     foreignTokenFactory,
     homeTokenFactory,
@@ -61,7 +59,6 @@ async function deployOmnibridgeNFT() {
     factory: foreignTokenFactory.address,
     bridge: foreignBridgeMediator.address,
     oppositeBridge: homeBridgeMediator.address,
-    erc721BridgeImage: foreignBridgeTokenImageERC721.address,
     erc721NativeImage: foreignNativeTokenImageERC721.address,
   })
 
@@ -69,7 +66,6 @@ async function deployOmnibridgeNFT() {
     factory: homeTokenFactory.address,
     bridge: homeBridgeMediator.address,
     oppositeBridge: foreignBridgeMediator.address,
-    erc721BridgeImage: homeBridgeTokenImageERC721.address,
     erc721NativeImage: homeNativeTokenImageERC721.address,
   })
 

--- a/deploy/src/omnibridge_nft/initializeFactory.js
+++ b/deploy/src/omnibridge_nft/initializeFactory.js
@@ -3,23 +3,19 @@ const { sendRawTxForeign, sendRawTxHome, transferProxyOwnership } = require('../
 const { ERC721TokenFactory, EternalStorageProxy } = require('../loadContracts')
 const { FOREIGN_UPGRADEABLE_ADMIN, HOME_UPGRADEABLE_ADMIN } = require('../loadEnv')
 
-function initializeERC721TokenFactory({
-  contract,
-  params: { erc721BridgeImage, erc721NativeImage, bridge, oppositeBridge, owner },
-}) {
+function initializeERC721TokenFactory({ contract, params: { erc721NativeImage, bridge, oppositeBridge, owner } }) {
   console.log(`
-    ERC721 BRIDGE IMAGE CONTRACT: ${erc721BridgeImage},
     ERC721 NATIVE IMAGE CONTRACT: ${erc721NativeImage},
     BRIDGE: ${bridge},
     OPPOSITE BRIDGE : ${oppositeBridge},
     OWNER: ${owner}`)
 
-  return contract.methods.initialize(erc721BridgeImage, erc721NativeImage, bridge, oppositeBridge, owner).encodeABI()
+  return contract.methods.initialize(erc721NativeImage, bridge, oppositeBridge, owner).encodeABI()
 }
 
 const { HOME_TOKEN_FACTORY_OWNER, FOREIGN_TOKEN_FACTORY_OWNER } = require('../loadEnv')
 
-async function initializeForeign({ factory, erc721BridgeImage, erc721NativeImage, bridge, oppositeBridge }) {
+async function initializeForeign({ factory, erc721NativeImage, bridge, oppositeBridge }) {
   let nonce = await web3Foreign.eth.getTransactionCount(deploymentFactoryAddress)
   const contract = new web3Foreign.eth.Contract(ERC721TokenFactory.abi, factory)
 
@@ -28,7 +24,6 @@ async function initializeForeign({ factory, erc721BridgeImage, erc721NativeImage
   const initializeData = initializeERC721TokenFactory({
     contract,
     params: {
-      erc721BridgeImage,
       erc721NativeImage,
       bridge,
       oppositeBridge,
@@ -54,7 +49,7 @@ async function initializeForeign({ factory, erc721BridgeImage, erc721NativeImage
   })
 }
 
-async function initializeHome({ factory, erc721BridgeImage, erc721NativeImage, bridge, oppositeBridge }) {
+async function initializeHome({ factory, erc721NativeImage, bridge, oppositeBridge }) {
   let nonce = await web3Home.eth.getTransactionCount(deploymentFactoryAddress)
   const contract = new web3Home.eth.Contract(ERC721TokenFactory.abi, factory)
 
@@ -63,7 +58,6 @@ async function initializeHome({ factory, erc721BridgeImage, erc721NativeImage, b
   const initializeData = initializeERC721TokenFactory({
     contract,
     params: {
-      erc721BridgeImage,
       erc721NativeImage,
       bridge,
       oppositeBridge,

--- a/test/omnibridge_nft/common.test.js
+++ b/test/omnibridge_nft/common.test.js
@@ -14,7 +14,7 @@ const NFTForwardingRulesManager = artifacts.require('NFTForwardingRulesManager')
 const SelectorTokenGasLimitManager = artifacts.require('SelectorTokenGasLimitManager')
 const OwnedUpgradeabilityProxy = artifacts.require('OwnedUpgradeabilityProxy')
 const selectors = {
-  deployAndHandleBridgedNFT: '0xd376e39a',
+  deployAndHandleBridgedNFT: '0xee75fe85',
   handleBridgedNFT: '0xb701e094',
   handleNativeNFT: '0x6ca48357',
   fixFailedMessage: '0x276fea8a',
@@ -83,8 +83,7 @@ function runTests(accounts, isHome) {
         [opts.tokenId],
         [],
         [uriFor(opts.tokenId)],
-        opts.id || 0,
-        opts.owner || owner
+        [opts.id || 0, opts.owner || owner, opts.image || tokenBridgeImageERC721.address]
       )
       .encodeABI()
   }
@@ -127,8 +126,7 @@ function runTests(accounts, isHome) {
         opts.tokenIds,
         opts.values,
         opts.tokenIds.map(uriFor),
-        opts.id || 0,
-        opts.owner || owner
+        [opts.id || 0, opts.owner || owner, opts.image || tokenBridgeImageERC721.address]
       )
       .encodeABI()
   }
@@ -175,7 +173,6 @@ function runTests(accounts, isHome) {
   async function initializeFactory(options) {
     const opts = options || {}
     const args = [
-      opts.erc721BridgeImage || tokenBridgeImageERC721.address,
       opts.erc721NativeImage || tokenNativeImageERC721.address,
       opts.bridge || contract.address,
       opts.oppositeBridge || contract.address,
@@ -1208,7 +1205,7 @@ function runTests(accounts, isHome) {
             // WARNING: don't remove comment, it's code prepare for source chain data
             // const tokenBridgeImageERC721 = await ERC721BridgeToken.new('TEST', 'TST', owner, { from: user3 })
             // expect(tokenBridgeImageERC721.address).to.eql('0x9Ad61E35f8309aF944136283157FABCc5AD371E5')
-            // const tokenNativeImageERC721 = await ERC721NativeToken.new('TEST', 'TST', { from: user3 })
+            // const tokenNativeImageERC721 = await ERC721NativeToken.new('TEST', 'TST', owner, { from: user3 })
             // expect(tokenNativeImageERC721.address).to.eql('0xc0bAC7B9a8c62778bBBad8BB859FDb8E9eA6203A')
             // const tokenFactoryERC721 = await ERC721TokenFactory.new({
             //   from: user3,
@@ -1216,13 +1213,7 @@ function runTests(accounts, isHome) {
             // expect(tokenFactoryERC721.address).to.eql('0x47115d34326e88AAD58066d8E4d033676fC1aBAe')
             // const bridge = '0x32cF26d114e5cCEc96B0666185d72a2F32D6A685'
             // const oppositeBridge = await Mediator.new(SUFFIX, { from: user3 })
-            // await tokenFactoryERC721.initialize(
-            //   tokenBridgeImageERC721.address,
-            //   tokenNativeImageERC721.address,
-            //   bridge,
-            //   oppositeBridge.address,
-            //   user3
-            // )
+            // await tokenFactoryERC721.initialize(tokenNativeImageERC721.address, bridge, oppositeBridge.address, user3)
             // expect(oppositeBridge.address).to.eql('0x32cF26d114e5cCEc96B0666185d72a2F32D6A685')
             // await tokenFactoryERC721.transferOwnership(owner, { from: user3 })
             // await tokenFactoryERC721.deployERC721NativeContract('TEST', 'TST')
@@ -1230,9 +1221,9 @@ function runTests(accounts, isHome) {
             // expect(event.length).to.be.equal(1)
             // // eslint-disable-next-line no-underscore-dangle
             // const erc721NativeTokenAddress = event[0].returnValues._collection
-            // expect(erc721NativeTokenAddress).to.eql('0x2E56870889CBa2837c234408634d02a502A488D8')
+            // expect(erc721NativeTokenAddress).to.eql('0x1FC9b7E9ffE83A83b89a88180416a5d216F3fAd8')
             // Execute at opposite chain
-            const computeCreate2AddrSourceChain = '0x2E56870889CBa2837c234408634d02a502A488D8'
+            const computeCreate2AddrSourceChain = '0x1FC9b7E9ffE83A83b89a88180416a5d216F3fAd8'
             // CREATE opcode same address
             const tokenNativeImageERC721 = await ERC721NativeToken.new('TEST', 'TST', owner, { from: user3 })
             expect(tokenNativeImageERC721.address).to.eql('0x9Ad61E35f8309aF944136283157FABCc5AD371E5')
@@ -1244,16 +1235,9 @@ function runTests(accounts, isHome) {
             expect(tokenFactoryERC721.address).to.eql('0x47115d34326e88AAD58066d8E4d033676fC1aBAe')
             const oppositeBridge = '0x32cF26d114e5cCEc96B0666185d72a2F32D6A685'
             const bridge = await Mediator.new(SUFFIX, { from: user3 })
-            await tokenFactoryERC721.initialize(
-              tokenBridgeImageERC721.address,
-              tokenNativeImageERC721.address,
-              bridge.address,
-              oppositeBridge,
-              user3
-            )
+            await tokenFactoryERC721.initialize(tokenNativeImageERC721.address, bridge.address, oppositeBridge, user3)
             expect(bridge.address).to.eql('0x32cF26d114e5cCEc96B0666185d72a2F32D6A685')
             await tokenFactoryERC721.transferOwnership(owner, { from: user3 })
-
             if (isHome) {
               await bridge.initialize(
                 ambBridgeContract.address,
@@ -1283,8 +1267,7 @@ function runTests(accounts, isHome) {
                 [1],
                 [],
                 [uriFor(1)],
-                0,
-                owner
+                [0, owner, tokenBridgeImageERC721.address]
               )
               .encodeABI()
             // execute message

--- a/test/omnibridge_nft/erc721_native_token.test.js
+++ b/test/omnibridge_nft/erc721_native_token.test.js
@@ -5,7 +5,7 @@ const ERC721NativeToken = artifacts.require('ERC721NativeToken')
 
 const uriFor = (tokenId) => `https://example.com/${tokenId}`
 
-contract.only('ERC721NativeToken', (accounts) => {
+contract('ERC721NativeToken', (accounts) => {
   let token
 
   const owner = accounts[0]


### PR DESCRIPTION
- Fix #16
- Relate to #14

# Problem:
- When deploying the ERC721BridgeToken collection, we need the ERC721BridgeToken image. To support deploying the same address in both chains, we need the ERC721NativeToken image address and the ERC721BridgeToken address same address. This will cause problems when we need to change the ERC721NativeToken image and the ERC721BridgeToken image.

# Solution:

- Store ERC721BridgeToken image address inside deployed message (not store on-chain) => ERC721BridgeToken image address will be always same with ERC721NativeToken image
