### PR TITLE
feat: support lazy mint

### DIFF
--- a/contracts/tokens/ERC721BridgeToken.sol
+++ b/contracts/tokens/ERC721BridgeToken.sol
@@ -18,7 +18,8 @@ contract ERC721BridgeToken is ERC721, IBurnableMintableERC721Token {
     uint256 private _id;
     address private _owner;
     Counters.Counter private _tokenIdCounter;
-
+    address private _minter;
+    
     constructor(
         string memory _name,
         string memory _symbol,

--- a/contracts/tokens/ERC721NativeToken.sol
+++ b/contracts/tokens/ERC721NativeToken.sol
@@ -13,6 +13,7 @@ contract ERC721NativeToken is ERC721 {
     uint256 private _id;
     address private _owner;
     Counters.Counter private _tokenIdCounter;
+    address private _minter;
 
     constructor(
         string memory _name,
@@ -31,6 +32,10 @@ contract ERC721NativeToken is ERC721 {
         _;
     }
 
+    function minter() public view returns (address) {
+        return _minter;
+    }
+
     function owner() public view returns (address) {
         return _owner;
     }
@@ -39,7 +44,8 @@ contract ERC721NativeToken is ERC721 {
         return _factory;
     }
 
-    function mint(address _to, string memory _uri) external onlyOwner {
+    function mint(address _to, string memory _uri) external {
+        require(msg.sender == _owner || msg.sender == _minter);
         _tokenIdCounter.increment();
         uint256 _tokenId = _tokenIdCounter.current();
 
@@ -66,6 +72,10 @@ contract ERC721NativeToken is ERC721 {
 
     function burn(uint256 tokenId) public virtual onlyOwner {
         _burn(tokenId);
+    }
+
+    function setMinter(address minter_) public onlyOwner {
+        _minter = minter_;
     }
 
     /**

--- a/contracts/upgradeable_contracts/omnibridge_nft/components/bridged/ERC721TokenProxy.sol
+++ b/contracts/upgradeable_contracts/omnibridge_nft/components/bridged/ERC721TokenProxy.sol
@@ -29,6 +29,7 @@ contract ERC721TokenProxy is Proxy {
     uint256 private _id;
     address private _owner;
     uint256 private _tokenIdCounter;
+    address private _minter;
 
     constructor(
         address _tokenImage,


### PR DESCRIPTION
# Updates:
- add `_minter` 
- add function `setMinter`, only owner can call this function

# Migrate guide:
- Re-deploy `ERC721NativeToken`, `ERC721BridgeToken` both side chains
- Re-deploy `ERC721TokenFactory` both side chains (because we modified ERC721TokenProxy)

# Notes:
- `ERC721TokenFactory` all bridge NFT will be gone